### PR TITLE
Address new pylint 2.11.1 warnings related to f-strings and file enco…

### DIFF
--- a/spotfire/cabfile.py
+++ b/spotfire/cabfile.py
@@ -31,11 +31,11 @@ if sys.platform == "win32":
             return self.close()
 
         def __repr__(self) -> str:
-            result = ["<%s.%s" % (self.__class__.__module__, self.__class__.__qualname__)]
+            result = [f"<{self.__class__.__module__}.{self.__class__.__qualname__}"]
             if not self._opened:
                 result.append(" [closed]")
             elif self.filename is not None:
-                result.append(" filename=%r" % self.filename)
+                result.append(f" filename={self.filename!r}")
             result.append(">")
             return "".join(result)
 

--- a/spotfire/codesign.py
+++ b/spotfire/codesign.py
@@ -191,9 +191,9 @@ if sys.platform == "win32":
         try:
             # Sanity check arguments
             if not os.path.isfile(filename):
-                raise FileNotFoundError("No such file: '%s'" % filename)
+                raise FileNotFoundError(f"No such file: '{filename}'")
             if not os.path.isfile(certificate):
-                raise FileNotFoundError("No such file: '%s'" % certificate)
+                raise FileNotFoundError(f"No such file: '{certificate}'")
             if use_sha256 and not use_rfc3161:
                 raise Exception("SHA-256 timestamping requires the RFC 3161 timestamping protocol")
 
@@ -238,7 +238,7 @@ if sys.platform == "win32":
         if cert_store is None:
             cert_store = _pfx_import_cert_store(ctypes.byref(cert_blob), None, 0)
         if cert_store is None:
-            raise Exception("Could not load certificate; is the password correct? (0x%08x)" % ctypes.GetLastError())
+            raise Exception(f"Could not load certificate; is the password correct? (0x{ctypes.GetLastError():08x})")
         return cert_store
 
 
@@ -247,7 +247,7 @@ if sys.platform == "win32":
         cert_context = _cert_find_cert_in_store(cert_store, _X509_ASN_ENCODING | _PKCS_7_ASN_ENCODING, 0,
                                                 _CERT_FIND_ANY, None, None)
         if cert_context is None:
-            raise Exception("Could not get certificate from store (0x%08x)" % ctypes.GetLastError())
+            raise Exception(f"Could not get certificate from store (0x{ctypes.GetLastError():08x})")
         key_spec = wintypes.DWORD()
         found_private_key = False
         while not found_private_key:
@@ -260,7 +260,7 @@ if sys.platform == "win32":
                 cert_context = _cert_find_cert_in_store(cert_store, _X509_ASN_ENCODING | _PKCS_7_ASN_ENCODING, 0,
                                                         _CERT_FIND_ANY, None, cert_context)
                 if cert_context is None:
-                    raise Exception("Could not get certificate from store (0x%08x)" % ctypes.GetLastError())
+                    raise Exception(f"Could not get certificate from store (0x{ctypes.GetLastError():08x})")
         return cert_context
 
 
@@ -322,7 +322,7 @@ if sys.platform == "win32":
         if signer_context is not None:
             _signer_free_context(signer_context)
         if result is not _S_OK:
-            raise Exception("Could not sign file (0x%08x)" % ctypes.GetLastError())
+            raise Exception(f"Could not sign file (0x{ctypes.GetLastError():08x})")
 
 
     def _timestamp(signer_subject_info, timestamp, use_rfc3161, use_sha256):
@@ -342,4 +342,4 @@ if sys.platform == "win32":
             else:
                 result = _signer_timestamp(ctypes.byref(signer_subject_info), timestamp, None, None)
             if result is not _S_OK:
-                raise Exception("Could not timestamp file (0x%08x)" % ctypes.GetLastError())
+                raise Exception(f"Could not timestamp file (0x{ctypes.GetLastError():08x})")

--- a/spotfire/data_function.py
+++ b/spotfire/data_function.py
@@ -76,7 +76,7 @@ class AnalyticInput:
         self.file = file
 
     def __repr__(self) -> str:
-        return "%s(%r, %r, %r)" % (_utils.type_name(type(self)), self.name, self.type, self.file)
+        return f"{_utils.type_name(type(self))}({self.name!r}, {self.type!r}, {self.file!r})"
 
     def read(self, globals_dict: typing.Dict[str, typing.Any], debug_fn: typing.Callable[[str], None]) -> None:
         """Read an input from the corresponding SBDF file into the dict that comprises the set of globals.
@@ -85,12 +85,12 @@ class AnalyticInput:
         :param debug_fn: logging function for debug messages
         """
         if self.type == "NULL":
-            debug_fn("assigning missing '%s' as None" % self.name)
+            debug_fn(f"assigning missing '{self.name}' as None")
             globals_dict[self.name] = None
             return
-        debug_fn("assigning %s '%s' from file %s" % (self.type, self.name, self.file))
+        debug_fn(f"assigning {self.type} '{self.name}' from file {self.file}")
         dataframe = sbdf.import_data(self.file)
-        debug_fn("read %d rows %d columns" % (dataframe.shape[0], dataframe.shape[1]))
+        debug_fn(f"read {dataframe.shape[0]} rows {dataframe.shape[1]} columns")
         try:
             table_meta = dataframe.spotfire_table_metadata
         except AttributeError:
@@ -105,8 +105,8 @@ class AnalyticInput:
         pretty_column = io.StringIO()
         pprint.pprint(table_meta, pretty_table)
         pprint.pprint(column_meta, pretty_column)
-        debug_fn("table metadata: \n %s" % pretty_table.getvalue())
-        debug_fn("column metadata: \n %s" % pretty_column.getvalue())
+        debug_fn(f"table metadata: \n {pretty_table.getvalue()}")
+        debug_fn(f"column metadata: \n {pretty_column.getvalue()}")
         if self.type == "column":
             dataframe = dataframe[dataframe.columns[0]]
         if self.type == "value":
@@ -137,7 +137,7 @@ class AnalyticOutput:
         self.file = file
 
     def __repr__(self) -> str:
-        return "%s(%r, %r)" % (_utils.type_name(type(self)), self.name, self.file)
+        return f"{_utils.type_name(type(self))}({self.name!r}, {self.file!r})"
 
     def write(self, globals_dict: typing.Dict[str, typing.Any], debug_fn: typing.Callable[[str], None]) -> None:
         """Write an output from the dict that comprises the set of globals file into the corresponding SBDF.
@@ -145,7 +145,7 @@ class AnalyticOutput:
         :param globals_dict: dict containing the global variables from the data function
         :param debug_fn: logging function for debug messages
         """
-        debug_fn("returning '%s' as file %s" % (self.name, self.file))
+        debug_fn(f"returning '{self.name}' as file {self.file}")
         sbdf.export_data(globals_dict[self.name], self.file, default_column_name=self.name)
 
 
@@ -209,8 +209,8 @@ class AnalyticSpec:
         :param script: the Python script code this data function will run
         """
         self.analytic_type = analytic_type
-        self.inputs = inputs if isinstance(inputs, list) else list()
-        self.outputs = outputs if isinstance(outputs, list) else list()
+        self.inputs = inputs if isinstance(inputs, list) else []
+        self.outputs = outputs if isinstance(outputs, list) else []
         self.script = script
         self.debug_enabled = False
         self.globals = dict(__builtins__=__builtins__)
@@ -218,8 +218,8 @@ class AnalyticSpec:
         self.compiled_script = None
 
     def __repr__(self) -> str:
-        return "%s(%r, %r, %r, %r)" % (_utils.type_name(type(self)), self.analytic_type, self.inputs, self.outputs,
-                                       self.script)
+        return f"{_utils.type_name(type(self))}({self.analytic_type!r}, \
+            {self.inputs!r}, {self.outputs!r}, {self.script!r})"
 
     def enable_debug(self) -> None:
         """Turn on the printing of debugging messages."""
@@ -231,7 +231,7 @@ class AnalyticSpec:
         :param message: the debugging message to print
         """
         if self.debug_enabled:
-            self.log.write("debug: %s\n" % message)
+            self.log.write(f"debug: {message}\n")
 
     def debug_write_script(self) -> None:
         """Output the current script to the debugging log."""
@@ -302,27 +302,24 @@ class AnalyticSpec:
 
     def _read_inputs(self, result: AnalyticResult) -> None:
         """read inputs"""
-        self.debug("reading %d input variables" % len(self.inputs))
+        self.debug(f"reading {len(self.inputs)} input variables")
         for i, input_ in enumerate(self.inputs):
             if _bad_string(input_.name) or input_.name == "":
-                self.debug("input %d: bad input variable name - skipped" % i)
+                self.debug(f"input {i}: bad input variable name - skipped")
                 continue
             if input_.type != "NULL" and (_bad_string(input_.file) or input_.file == ""):
-                self.debug("input '%s': bad file name - skipped" % input_.name)
+                self.debug(f"input '{input_.name}': bad file name - skipped")
                 continue
             if input_.type != "NULL" and not os.path.isfile(input_.file):
-                self.debug("input '%s': non-existent file - skipped" % input_.name)
+                self.debug(f"input '{input_.name}': non-existent file - skipped")
                 continue
             try:
                 input_.read(self.globals, self.debug)
             except sbdf.SBDFError as exc:
-                self.debug("error reading input variable '%s' from file '%s': %s"
-                           % (input_.name,
-                              input_.file,
-                              str(exc)))
+                self.debug(f"error reading input variable '{input_.name}' from file '{input_.file}': {str(exc)}")
                 result.fail_with_exception(sys.exc_info())
                 return
-        self.debug("done reading %d input variables" % len(self.inputs))
+        self.debug(f"done reading {len(self.inputs)} input variables")
         return
 
     def _execute_script(self, compiled_script: typing.Any, result: AnalyticResult) -> None:
@@ -334,7 +331,7 @@ class AnalyticSpec:
         self.debug("--- script ---")
         if _bad_string(self.analytic_type):
             self.analytic_type = "script"
-        self.debug("analytic_type is '%s'" % self.analytic_type)
+        self.debug(f"analytic_type is '{self.analytic_type}'")
         if self.analytic_type == "script":
             # noinspection PyBroadException
             try:
@@ -350,23 +347,23 @@ class AnalyticSpec:
 
     def _write_outputs(self, result: AnalyticResult) -> None:
         """write outputs"""
-        self.debug("writing %d output variables" % len(self.outputs))
+        self.debug(f"writing {len(self.outputs)} output variables")
         for i, output in enumerate(self.outputs):
             if _bad_string(output.name) or output.name == "":
-                self.debug("output %d: bad output variable name - skipped" % i)
+                self.debug(f"output {i}: bad output variable name - skipped")
                 continue
             if _bad_string(output.file) or output.file == "":
-                self.debug("output '%s': bad file name - skipped" % output.name)
+                self.debug(f"output '{output.name}': bad file name - skipped")
                 continue
             if output.name not in self.globals:
-                self.debug("output variable '%s' not defined in globals" % output.name)
-                raise DataFunctionError("Output variable '%s' was not defined" % output.name)
+                self.debug(f"output variable '{output.name}' not defined in globals")
+                raise DataFunctionError(f"Output variable '{output.name}' was not defined")
             # noinspection PyBroadException
             try:
                 output.write(self.globals, self.debug)
             except BaseException:
                 result.fail_with_exception(sys.exc_info())
-        self.debug("done writing %d output variables" % len(self.outputs))
+        self.debug(f"done writing {len(self.outputs)} output variables")
 
     def _summarize(self, result: AnalyticResult) -> AnalyticResult:
         """Perform final summary actions and return the result object."""
@@ -392,8 +389,8 @@ class AnalyticSpec:
                             syntax_error = traceback.TracebackException(result.get_exc_info()[0],
                                                                         result.get_exc_info()[1],
                                                                         result.get_exc_info()[2])
-                            buf.write('  File "%s", line %s\n' % (syntax_error.filename, syntax_error.lineno))
-                            buf.write("    %s" % syntax_error.text)
+                            buf.write(f'  File "{syntax_error.filename}", line {syntax_error.lineno}\n')
+                            buf.write(f"    {syntax_error.text}")
                             # sometimes the offset is wrong, placing the caret before or after the text.
                             spacer = syntax_error.offset - 1
                             if exc_type == "IndentationError":
@@ -401,8 +398,8 @@ class AnalyticSpec:
                             if len(syntax_error.text) == syntax_error.offset:
                                 spacer -= 1
                             offset = " " * spacer
-                            buf.write("    %s^\n" % offset)
-                        buf.write("%s: %s\n\n" % (exc_type, result.get_exc_info()[1]))
+                            buf.write(f"    {offset}^\n")
+                        buf.write(f"{exc_type}: {result.get_exc_info()[1]}\n\n")
                         buf.write("Traceback (most recent call last):\n")
                         # get the StackSummary
                         tb_frames = traceback.extract_tb(result.get_exc_info()[2])
@@ -412,12 +409,12 @@ class AnalyticSpec:
                         # trim the path from the filename
                         def shorten(match):
                             """trim the path from the exception filename"""
-                            return 'File "{}"'.format(os.path.basename(match.group(1)))
+                            return f'File "{os.path.basename(match.group(1))}"'
 
                         lines = [re.sub(r'File "([^"]+)"', shorten, line, 1) for line in lines]
                         buf.writelines(lines)
                     except BaseException:
-                        buf.write("\nCould not retrieve stacktrace: %s" % traceback.print_exc())
+                        buf.write(f"\nCould not retrieve stacktrace: {traceback.print_exc()}")
             if result.get_capture() is not None:
                 out = result.get_capture().get_stdout()
                 if out is not None:

--- a/spotfire/test/__main__.py
+++ b/spotfire/test/__main__.py
@@ -20,6 +20,6 @@ def load_tests(loader, tests, pattern):  # pylint: disable=unused-argument
     return test_suite
 
 
-with open("results-%s.xml" % utils.PYTHON_VERSION, "wb") as output:
+with open(f"results-{utils.PYTHON_VERSION}.xml", "wb") as output:
     unittest.main(testRunner=xmlrunner.XMLTestRunner(output=output, resultclass=utils.PythonVersionModifiedResult),
                   failfast=False, buffer=False, catchbreak=False, exit=False)

--- a/spotfire/test/test_data_function.py
+++ b/spotfire/test/test_data_function.py
@@ -24,7 +24,7 @@ class DataFunctionTest(unittest.TestCase):
             for k in inputs:
                 if inputs[k] is None:
                     in_type = "NULL"
-                    print("test: missing input '%s' " % k)
+                    print(f"test: missing input '{k}' ")
                     input_spec.append(datafn.AnalyticInput(k, in_type, None))
                     continue
                 if isinstance(inputs[k], pd.DataFrame):
@@ -37,7 +37,7 @@ class DataFunctionTest(unittest.TestCase):
                 tmp = temp_files.new_file(suffix=".sbdf")
                 tmp.close()
                 sbdf.export_data(inputs[k], tmp.name, k)
-                print("test: writing input %s '%s' to file '%s'" % (in_type, k, tmp.name))
+                print(f"test: writing input {in_type} '{k}' to file '{tmp.name}'")
                 input_spec.append(datafn.AnalyticInput(k, in_type, tmp.name))
             output_spec = []
             for k in outputs:
@@ -74,19 +74,19 @@ class DataFunctionTest(unittest.TestCase):
             print("test: done evaluating spec")
 
             for output in output_spec:
-                print("test: reading output variable '%s' from file '%s'" % (output.name, output.file))
+                print(f"test: reading output variable '{output.name}' from file '{output.file}'")
                 if os.path.isfile(output.file):
                     try:
                         data_frame = sbdf.import_data(output.file)
                         print(data_frame)
                         pdtest.assert_frame_equal(outputs[output.name], data_frame)
                         try:
-                            print("test: table metadata:\n%r" % data_frame.spotfire_table_metadata)
+                            print(f"test: table metadata:\n{data_frame.spotfire_table_metadata!r}")
                         except AttributeError:
                             pass
                         for col in data_frame.columns:
                             try:
-                                print("test: column '%s' metadata:\n%r" % (col, data_frame[col].spotfire_column_metadata))
+                                print(f"test: column '{col}' metadata:\n{data_frame[col].spotfire_column_metadata!r}")
                             except AttributeError:
                                 pass
                         self._assert_table_metadata_equal(outputs[output.name], data_frame)
@@ -386,7 +386,7 @@ Traceback (most recent call last):
   File "data_function.py", line 255, in evaluate
     self._write_outputs(result)
   File "data_function.py", line 346, in _write_outputs
-    raise DataFunctionError("Output variable '%s' was not defined" % output.name)
+    raise DataFunctionError(f"Output variable '{output.name}' was not defined")
 """)
 
     def test_table_metadata(self):

--- a/spotfire/test/test_sbdf.py
+++ b/spotfire/test/test_sbdf.py
@@ -15,23 +15,23 @@ class SbdfTest(unittest.TestCase):
 
     def test_read_0(self):
         """Reading simple SBDF files should work."""
-        dataframe = sbdf.import_data("%s/files/sbdf/0.sbdf" % os.path.dirname(__file__))
+        dataframe = sbdf.import_data(f"{os.path.dirname(__file__)}/files/sbdf/0.sbdf")
         self.assertEqual(dataframe.shape, (0, 12))
 
         def verify(dict_, pre, post):
             """Check all metadata entries for a given table/column."""
-            self.assertEqual(dict_["%sMetaBoolean%s" % (pre, post)][0], True)
-            self.assertEqual(dict_["%sMetaInteger%s" % (pre, post)][0], 3)
-            self.assertEqual(dict_["%sMetaLong%s" % (pre, post)][0], 2)
-            self.assertAlmostEqual(dict_["%sMetaFloat%s" % (pre, post)][0], 0.333333343267441)
-            self.assertEqual(dict_["%sMetaDouble%s" % (pre, post)][0], 3.14)
-            self.assertEqual(dict_["%sMetaDateTime%s" % (pre, post)][0], datetime.datetime(1583, 1, 1))
-            self.assertEqual(dict_["%sMetaDate%s" % (pre, post)][0], datetime.date(1583, 1, 1))
-            self.assertEqual(dict_["%sMetaTime%s" % (pre, post)][0], datetime.time(0, 0, 33))
-            self.assertEqual(dict_["%sMetaTimeSpan%s" % (pre, post)][0], datetime.timedelta(0, 12, 300000))
-            self.assertEqual(dict_["%sMetaString%s" % (pre, post)][0], "The")
-            self.assertEqual(dict_["%sMetaDecimal%s" % (pre, post)][0], decimal.Decimal('33.4455'))
-            self.assertEqual(dict_["%sMetaBinary%s" % (pre, post)][0], b"\x01")
+            self.assertEqual(dict_[f"{pre}MetaBoolean{post}"][0], True)
+            self.assertEqual(dict_[f"{pre}MetaInteger{post}"][0], 3)
+            self.assertEqual(dict_[f"{pre}MetaLong{post}"][0], 2)
+            self.assertAlmostEqual(dict_[f"{pre}MetaFloat{post}"][0], 0.333333343267441)
+            self.assertEqual(dict_[f"{pre}MetaDouble{post}"][0], 3.14)
+            self.assertEqual(dict_[f"{pre}MetaDateTime{post}"][0], datetime.datetime(1583, 1, 1))
+            self.assertEqual(dict_[f"{pre}MetaDate{post}"][0], datetime.date(1583, 1, 1))
+            self.assertEqual(dict_[f"{pre}MetaTime{post}"][0], datetime.time(0, 0, 33))
+            self.assertEqual(dict_[f"{pre}MetaTimeSpan{post}"][0], datetime.timedelta(0, 12, 300000))
+            self.assertEqual(dict_[f"{pre}MetaString{post}"][0], "The")
+            self.assertEqual(dict_[f"{pre}MetaDecimal{post}"][0], decimal.Decimal('33.4455'))
+            self.assertEqual(dict_[f"{pre}MetaBinary{post}"][0], b"\x01")
 
         # Check table metadata
         verify(dataframe.spotfire_table_metadata, "SbdfTest.Table", "")
@@ -51,7 +51,7 @@ class SbdfTest(unittest.TestCase):
 
     def test_read_1(self):
         """Reading simple SBDF files should work."""
-        dataframe = sbdf.import_data("%s/files/sbdf/1.sbdf" % os.path.dirname(__file__))
+        dataframe = sbdf.import_data(f"{os.path.dirname(__file__)}/files/sbdf/1.sbdf")
         self.assertEqual(dataframe.shape, (1, 12))
         self.assertEqual(dataframe.at[0, "Boolean"], False)
         self.assertEqual(dataframe.at[0, "Integer"], 69)
@@ -67,7 +67,7 @@ class SbdfTest(unittest.TestCase):
 
     def test_read_100(self):
         """Reading simple SBDF files should work."""
-        dataframe = sbdf.import_data("%s/files/sbdf/100.sbdf" % os.path.dirname(__file__))
+        dataframe = sbdf.import_data(f"{os.path.dirname(__file__)}/files/sbdf/100.sbdf")
         self.assertEqual(dataframe.shape, (100, 12))
         self.assertEqual(dataframe.get("Boolean")[0:6].tolist(), [False, True, None, False, True, None])
         self.assertEqual(dataframe.get("Integer")[0:6].dropna().tolist(), [69.0, 73.0, 75.0, 79.0])
@@ -85,7 +85,7 @@ class SbdfTest(unittest.TestCase):
 
     def test_read_10001(self):
         """Reading simple SBDF files should work."""
-        dataframe = sbdf.import_data("%s/files/sbdf/10001.sbdf" % os.path.dirname(__file__))
+        dataframe = sbdf.import_data(f"{os.path.dirname(__file__)}/files/sbdf/10001.sbdf")
         self.assertEqual(dataframe.shape, (10001, 12))
         # Check the values in the first row
         self.assertEqual(dataframe.at[0, "Boolean"], False)

--- a/spotfire/test/utils.py
+++ b/spotfire/test/utils.py
@@ -24,7 +24,7 @@ class PythonVersionModifiedResult(xmlrunner.result._XMLTestResult):  # pylint: d
             suite_name = suite
             if test_runner.outsuffix:
                 # not checking with 'is not None', empty means no suffix.
-                suite_name = '%s-%s' % (suite, test_runner.outsuffix)
+                suite_name = f'{suite}-{test_runner.outsuffix}'
 
             # Build the XML file
             testsuite = PythonVersionModifiedResult._report_testsuite(suite_name, tests, doc, parent_element,
@@ -37,4 +37,4 @@ class PythonVersionModifiedResult(xmlrunner.result._XMLTestResult):  # pylint: d
         test_runner.output.write(xml_content)
 
 
-PYTHON_VERSION = "py%d%d" % (sys.version_info.major, sys.version_info.minor)
+PYTHON_VERSION = f"py{sys.version_info.major}{sys.version_info.minor}"


### PR DESCRIPTION
…ding. (#14)

Pylint's standard is now to use f-strings rather than other ways of string formatting, primarily for efficiency and ease of reading. I've adapted all of these where appropriate and put in pylint exceptions, primarily for some strange tuple unpacking where it's just cleaner not to. There should be no change in behavior otherwise.

Also addressed a few other Pylint warnings where we didn't declare file encoding. I set these all to utf-8, assuming that's correct.