### PR TITLE
Added performance tuning on export data function for pandas DataFrame

### DIFF
--- a/spotfire/sbdf.py
+++ b/spotfire/sbdf.py
@@ -729,6 +729,7 @@ class _SbdfObject:
         """writes the object to the specified file. valuetype information is not written"""
         self._write_n(file, 1, False)
 
+    # pylint: disable=too-many-branches
     def _write_n(self, file: typing.BinaryIO, n: int, packed: bool) -> None:
         valtype = _ValueType(self.valuetype)
         if valtype.is_array():
@@ -1267,6 +1268,7 @@ class _ValueType:
         return bitstring.pack('uintle:96,pad:17,bits:7,bool,bits:7', coefficient, biased_exponent_bits_high,
                               dec.sign, biased_exponent_bits_low).bytes
 
+    # pylint: disable=no-else-return,too-many-return-statements
     def to_bytes(self, obj: typing.Any) -> bytes:
         """return a SBDF representation of the Python objects"""
         try:

--- a/spotfire/sbdf.py
+++ b/spotfire/sbdf.py
@@ -738,10 +738,10 @@ class _SbdfObject:
                 if isinstance(self.data, pd.Series):
                     barr = self.data.values.astype('S')
                     _write_int32(file, sum(_get_7bit_packed_length(len(s)) + len(s) for s in barr))
-                    for s in barr:
-                        _write_7bit_packed_int32(file, len(s))
-                        if len(s):
-                            _write_bytes(file, s)
+                    for bstr in barr:
+                        _write_7bit_packed_int32(file, len(bstr))
+                        if len(bstr):
+                            _write_bytes(file, bstr)
                 else:
                     saved_bytes = []
                     for i in range(n):
@@ -757,10 +757,10 @@ class _SbdfObject:
             else:
                 if isinstance(self.data, pd.Series):
                     barr = self.data.values.astype('S')
-                    for s in barr:
-                        _write_7bit_packed_int32(file, len(s))
-                        if len(s):
-                            _write_bytes(file, s)
+                    for bstr in barr:
+                        _write_7bit_packed_int32(file, len(bstr))
+                        if len(bstr):
+                            _write_bytes(file, bstr)
                 else:
                     for i in range(n):
                         valtype_bytes = valtype.to_bytes(self.data[i])
@@ -772,7 +772,7 @@ class _SbdfObject:
             size = valtype.get_packed_size()
             if size is None:
                 raise SBDFError("unknown typeid")
-            
+
             if isinstance(self.data, pd.Series):
                 _write_bytes(file, self.data.values.tobytes())
             else:
@@ -1273,27 +1273,27 @@ class _ValueType:
             name = self.type_id
             if name == _ValueTypeId.BOOL:
                 return self._to_bytes_bool(obj)
-            elif name == _ValueTypeId.INT: 
+            elif name == _ValueTypeId.INT:
                 return self._to_bytes_int(obj)
-            elif name == _ValueTypeId.LONG: 
+            elif name == _ValueTypeId.LONG:
                 return self._to_bytes_long(obj)
-            elif name == _ValueTypeId.FLOAT: 
+            elif name == _ValueTypeId.FLOAT:
                 return self._to_bytes_float(obj)
-            elif name == _ValueTypeId.DOUBLE: 
+            elif name == _ValueTypeId.DOUBLE:
                 return self._to_bytes_double(obj)
-            elif name == _ValueTypeId.DATETIME: 
+            elif name == _ValueTypeId.DATETIME:
                 return self._to_bytes_datetime(obj)
-            elif name == _ValueTypeId.DATE: 
+            elif name == _ValueTypeId.DATE:
                 return self._to_bytes_date(obj)
-            elif name == _ValueTypeId.TIME: 
+            elif name == _ValueTypeId.TIME:
                 return self._to_bytes_time(obj)
-            elif name == _ValueTypeId.TIMESPAN: 
+            elif name == _ValueTypeId.TIMESPAN:
                 return self._to_bytes_timespan(obj)
             elif name == _ValueTypeId.STRING:
                 return self._to_bytes_string(obj)
-            elif name == _ValueTypeId.BINARY: 
+            elif name == _ValueTypeId.BINARY:
                 return obj
-            elif name == _ValueTypeId.DECIMAL: 
+            elif name == _ValueTypeId.DECIMAL:
                 return self._to_bytes_decimal(obj)
             else:
                 return None


### PR DESCRIPTION
This PR contributes a faster `export_data` function specifically for pandas DataFrame with 10x speed up over the existing implementation in this repository. My script for benchmarking the time is as below.

```python
from spotfire.sbdf import export_data
import pandas as pd
import time


if __name__ == '__main__':
    df = pd.read_csv('./test.csv') # a dataframe with >10M rows and >100 columns
    df = df.iloc[:100000]

    int8_cols = df.columns[df.dtypes == 'int8']
    df[int8_cols] = df[int8_cols].astype(int)

    string_cols = df.columns[df.dtypes == 'string']
    df[string_cols] = df[string_cols].astype(str)

    start = time.time()
    export_data(df, './test.sbdf')
    print(time.time() - start)
```
Running in `main` branch
![image](https://user-images.githubusercontent.com/44737479/140449348-36affb40-e388-45b4-957b-bae601c2347f.png)
Running in `improve-pandas-export` branch
![image](https://user-images.githubusercontent.com/44737479/140449352-291732c2-e7d6-468b-a71f-831b272621c9.png)
